### PR TITLE
Implementación de botones submit #36

### DIFF
--- a/app/View/Components/Forms/SubmitButton.php
+++ b/app/View/Components/Forms/SubmitButton.php
@@ -11,10 +11,11 @@ class SubmitButton extends Component
     /**
      * Create a new component instance.
      */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct(
+        public string $btn_color = 'btn-neutral',
+        public string $class = '',
+        public ?string $value = null
+    ) {}
 
     /**
      * Get the view / contents that represent the component.

--- a/resources/views/components/forms/submit-button.blade.php
+++ b/resources/views/components/forms/submit-button.blade.php
@@ -1,11 +1,54 @@
 @props(['btn_color' => 'btn-neutral', 'class' => '', 'value' => null])
+
 <button
-        type="submit"
-        class="btn {{ $btn_color }} {{ $class }}"
-        @if(!is_null($value))
-            name="submit_action"
+    type="submit"
+    class="btn {{ $btn_color }} {{ $class }} relative submit-btn"
+    @if(!is_null($value))
+        name="submit_action"
         value="{{ $value }}"
-        @endif
+    @endif
 >
-    {{ $slot }}
+    <span class="btn-text whitespace-nowrap">{{ $slot }}</span>
+    
+    <!-- Loader -->
+    <span class="btn-loader absolute inset-0 hidden items-center justify-center">
+        <span class="loading loading-spinner loading-md"></span>
+    </span>
 </button>
+
+@push('scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const forms = document.querySelectorAll('form');
+        
+        forms.forEach(form => {
+            form.addEventListener('submit', function() {
+                const submitBtn = form.querySelector('.submit-btn');
+                if (!submitBtn) return;
+
+                const btnWidth = submitBtn.offsetWidth;
+                submitBtn.style.width = btnWidth + 'px';
+                submitBtn.disabled = true;
+
+                // Loader
+                submitBtn.querySelector('.btn-text').style.visibility = 'hidden';
+                const loader = submitBtn.querySelector('.btn-loader');
+                loader.classList.remove('hidden');
+                loader.style.display = 'flex';
+
+                // Deshabilitar inputs
+                form.querySelectorAll('input, textarea, select').forEach(input => {
+                    input.classList.add('pointer-events-none', 'opacity-60');
+                    input.readOnly = true;
+
+                    const parentContainer = input.closest('.select, .input-container');
+                    if (parentContainer) {
+                        parentContainer.classList.add('pointer-events-none', 'opacity-60');
+                    }
+                });
+            });
+        });
+    });
+</script>
+@endpush
+


### PR DESCRIPTION
Se implementó un loader a los botones de submit hasta que termine la request, además de deshabilitarse el mismo y los inputs para que no se puedan editar mientras se realiza la misma.

Imagen demostrativa:
![image](https://github.com/user-attachments/assets/7860d530-9e98-4ed8-ac24-0bf1b9175d5d)
