### PR TITLE
Cambiar el color de los links entre tablas

### DIFF
--- a/lang/en/files.php
+++ b/lang/en/files.php
@@ -10,6 +10,7 @@ return [
     'created_at' => 'Creation date',
     'actions' => 'Actions',
     'view_file' => 'View file',
+    'view_files' => 'View files',
     'edit' => 'Edit',
     'delete' => 'Delete',
     'no_files' => 'No files to show',

--- a/lang/en/general.php
+++ b/lang/en/general.php
@@ -52,4 +52,5 @@ return [
     'password' => 'Password',
     'spanish' => 'Spanish',
     'english' => 'English',
+    'view' => 'View',
 ];

--- a/lang/en/products.php
+++ b/lang/en/products.php
@@ -29,6 +29,7 @@ return [
     'product_restored' => 'Product restored successfully',
     'select_client' => 'Select a client',
     'create_product' => 'Create product',
+    'view_products' => 'View Products',
     'new_product' => 'New product',
     'upload_files' => 'Upload files',
     'generate_qr' => 'Generate QR',

--- a/lang/en/qrs.php
+++ b/lang/en/qrs.php
@@ -13,6 +13,7 @@ return [
     'pdf_generation_error' => 'There was a problem generating the PDF. Please try again.',
     'image_generation_error' => 'Could not generate the image. Please try again.',
     'create_qr' => 'Create QR',
+    'view_qrs' => 'View QRs',
     'qr_created' => 'QR created successfully',
     'qr_creation_error' => 'Error creating QR',
     'select_product' => 'Select a product',

--- a/lang/es/files.php
+++ b/lang/es/files.php
@@ -10,6 +10,7 @@ return [
     'created_at' => 'Fecha de creación',
     'actions' => 'Acciones',
     'view_file' => 'Ver archivo',
+    'view_files' => 'Ver archivos',
     'edit' => 'Editar',
     'delete' => 'Eliminar',
     'no_files' => 'No hay archivos para mostrar',

--- a/lang/es/general.php
+++ b/lang/es/general.php
@@ -52,4 +52,5 @@ return [
     'password' => 'Contraseña',
     'spanish' => 'Español',
     'english' => 'Inglés',
+    'view' => 'Ver',
 ];

--- a/lang/es/products.php
+++ b/lang/es/products.php
@@ -29,6 +29,7 @@ return [
     'product_restored' => 'Producto restaurado correctamente',
     'select_client' => 'Seleccione un cliente',
     'create_product' => 'Crear producto',
+    'view_products' => 'Ver Productos',
     'new_product' => 'Nuevo producto',
     'upload_files' => 'Subir archivos',
     'generate_qr' => 'Generar QR',

--- a/lang/es/qrs.php
+++ b/lang/es/qrs.php
@@ -13,6 +13,7 @@ return [
     'pdf_generation_error' => 'Hubo un problema al generar el PDF. Por favor, inténtelo de nuevo.',
     'image_generation_error' => 'No se pudo generar la imagen. Por favor, inténtelo de nuevo.',
     'create_qr' => 'Crear QR',
+    'view_qrs' => 'Ver QRs',
     'qr_created' => 'QR creado correctamente',
     'qr_creation_error' => 'Error al crear el QR',
     'select_product' => 'Seleccione un producto',

--- a/resources/views/admin/clients/index.blade.php
+++ b/resources/views/admin/clients/index.blade.php
@@ -40,19 +40,28 @@
                 <td>{{ $client->contact_phone }}</td>
                 <td>{{ $client->legal_address }}</td>
                 <td>
-                    <a href="{{ route('admin.products', ['client' => $client->id]) }}" class="text-primary hover:underline">
-                        {{ $client->products()->count() }}
-                    </a>
+                    <div class="tooltip" data-tip="{{ __('products.view_products') }}">
+                        <a href="{{ route('admin.products', ['client' => $client->id]) }}" class="badge text-xs badge-primary gap-1 cursor-pointer hover:brightness-90">
+                            {{ $client->products()->count() }}
+                            <x-icons.external-link class="h-4 w-4 text-white" />
+                        </a>
+                    </div>
                 </td>
                 <td>
-                    <a href="{{ route('admin.files', ['client' => $client->id]) }}" class="text-primary hover:underline">
-                        {{ $client->files_count }}
-                    </a>
+                    <div class="tooltip" data-tip="{{ __('files.view_files') }}">
+                        <a href="{{ route('admin.files', ['client' => $client->id]) }}" class="badge text-xs badge-primary gap-1 cursor-pointer hover:brightness-90">
+                            {{ $client->files_count }}
+                            <x-icons.external-link class="h-4 w-4 text-white" />
+                        </a>
+                    </div>
                 </td>
                 <td>
-                    <a href="{{ route('admin.qrs', ['client' => $client->id]) }}" class="text-primary hover:underline">
-                        {{ $client->qrs()->count() }}
-                    </a>
+                    <div class="tooltip" data-tip="{{ __('qrs.view_qrs') }}">
+                        <a href="{{ route('admin.qrs', ['client' => $client->id]) }}" class="badge text-xs badge-primary gap-1 cursor-pointer hover:brightness-90">
+                            {{ $client->qrs()->count() }}
+                            <x-icons.external-link class="h-4 w-4 text-white" />
+                        </a>
+                    </div>
                 </td>
                 <td>
                     <x-button-link

--- a/resources/views/admin/files/index.blade.php
+++ b/resources/views/admin/files/index.blade.php
@@ -37,14 +37,20 @@
                 <td>{{ $file->file_name ?: $file->original_file_name }}</td>
                 <td>{{ $file->original_file_name }}</td>
                 <td>
-                    <a href="{{ route('admin.products', ['client' => $file->product->client_id, 'name' => $file->product->name]) }}" class="text-primary hover:underline">
-                        {{ $file->product->name }}
-                    </a>
+                    <div class="tooltip" data-tip="{{ __('general.view') }} {{ $file->product->name }}">
+                        <a href="{{ route('admin.products', ['client' => $file->product->client_id, 'name' => $file->product->name]) }}" class="flex items-center gap-1 text-base-content font-bold underline hover:text-base-content/80">
+                            {{ $file->product->name }}
+                            <x-icons.external-link class="h-4 w-4" />
+                        </a>
+                    </div>
                 </td>
                 <td>
-                    <a href="{{ route('admin.clients', ['client' => $file->product->client_id]) }}" class="text-primary hover:underline">
-                        {{ $file->product->client->legal_name }}
-                    </a>
+                    <div class="tooltip" data-tip="{{ __('general.view') }} {{ $file->product->client->legal_name }}">
+                        <a href="{{ route('admin.clients', ['client' => $file->product->client_id]) }}" class="flex items-center gap-1 text-base-content font-bold underline hover:text-base-content/80">
+                            {{ $file->product->client->legal_name }}
+                            <x-icons.external-link class="h-4 w-4" />
+                        </a>
+                    </div>
                 </td>
                 <td>{{ $file->formatFileSize($file->file_size) }}</td>
                 <td>{{ $file->created_at->format('d/m/Y') }}</td>

--- a/resources/views/admin/products/index.blade.php
+++ b/resources/views/admin/products/index.blade.php
@@ -38,9 +38,12 @@
                 <td>{{ $product->model }}</td>
                 <td>{{ $product->origin }}</td>
                 <td>
-                    <a href="{{ route('admin.files', ['product' => $product->id]) }}" class="text-primary hover:underline">
-                        {{ $product->files->count() }}
-                    </a>
+                    <div class="tooltip" data-tip="{{ __('files.view_files') }}">
+                        <a href="{{ route('admin.files', ['product' => $product->id]) }}" class="badge text-xs badge-primary gap-1 cursor-pointer hover:brightness-90">
+                            {{ $product->files->count() }}
+                            <x-icons.external-link class="h-4 w-4 text-white" />
+                        </a>
+                    </div>
                 </td>
                 <td>
                     <x-button-link

--- a/resources/views/admin/qr/index.blade.php
+++ b/resources/views/admin/qr/index.blade.php
@@ -27,14 +27,20 @@
                 <td>{{ $qr->id }}</td>
                 <td>{{ $qr->client->legal_name }}</td>
                 <td>
-                    <a href="{{ route('admin.products', ['client' => $qr->client_id, 'name' => $qr->product->name]) }}" class="text-primary hover:underline">
-                        {{ $qr->product->name }}
-                    </a>
+                    <div class="tooltip" data-tip="{{ __('general.view') }} {{ $qr->product->name }}">
+                        <a href="{{ route('admin.products', ['client' => $qr->client_id, 'name' => $qr->product->name]) }}" class="flex items-center gap-1 text-base-content font-bold underline hover:text-base-content/80">
+                            {{ $qr->product->name }}
+                            <x-icons.external-link class="h-4 w-4" />
+                        </a>
+                    </div>
                 </td>
                 <td>
-                    <a href="{{ route('admin.files', ['product' => $qr->product_id]) }}" class="text-primary hover:underline">
-                        {{ $qr->product->files->count() }}
-                    </a>
+                    <div class="tooltip" data-tip="{{ __('files.view_files') }}">
+                        <a href="{{ route('admin.files', ['product' => $qr->product_id]) }}" class="badge text-xs badge-primary gap-1 cursor-pointer hover:brightness-90">
+                            {{ $qr->product->files->count() }}
+                            <x-icons.external-link class="h-4 w-4 text-white" />
+                        </a>
+                    </div>
                 </td>
                 <td>
                     <div class="tooltip" data-tip="{{ __('qrs.zoom') }}">

--- a/resources/views/components/icons/external-link.blade.php
+++ b/resources/views/components/icons/external-link.blade.php
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     class="{{ $class ?? 'h-5 w-5' }} {{ $color ?? 'text-gray-400 group-hover:text-gray-600' }}"
+     fill="none"
+     viewBox="0 0 24 24" 
+     stroke="currentColor">
+    <path stroke-linecap="round" 
+          stroke-linejoin="round" 
+          stroke-width="2"
+          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+</svg> 

--- a/resources/views/links.blade.php
+++ b/resources/views/links.blade.php
@@ -19,22 +19,12 @@
                            class="w-3/4 p-4 bg-gray-200 shadow-lg rounded-xl transition-all duration-300 hover:scale-105 hover:shadow-xl hover:bg-gray-50 group">
                             <div class="flex items-center justify-between">
                                 <div class="flex items-center space-x-3">
-                                    <svg xmlns="http://www.w3.org/2000/svg"
-                                         class="h-6 w-6 text-gray-500 group-hover:text-gray-600" fill="none"
-                                         viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                    </svg>
+                                    <x-icons.file-icon class="h-6 w-6 text-gray-500 group-hover:text-gray-600" />                      
                                     <span class="text-lg font-medium text-gray-700 group-hover:text-gray-800">
                                         {{ $file->file_name ?: 'Archivo PDF' }}
                                     </span>
                                 </div>
-                                <svg xmlns="http://www.w3.org/2000/svg"
-                                     class="h-5 w-5 text-gray-400 group-hover:text-gray-600" fill="none"
-                                     viewBox="0 0 24 24" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                                </svg>
+                                <x-icons.external-link class="h-5 w-5 text-gray-400 group-hover:text-gray-600"/>
                             </div>
                         </a>
                     @endforeach


### PR DESCRIPTION
## Descripción

Se cambió el color de los links entre tablas como se solicitó, y se agregaron tooltips para cada uno de los items, indicando a donde lleva cada uno. Además, para los datos numéricos, se usó un badge + tooltip.

## Checklist

- [ ] He descrito claramente los cambios realizados.
- [ ] He referenciado correctamente las issues que se resuelven.
- [ ] He cumplido todos los puntos referenciados en las issues.


## Imágenes demostrativas:

------Código actual------
![Screenshot_1](https://github.com/user-attachments/assets/4ce4a00a-8dd1-4710-a2bd-9e35784cc39d)
![Screenshot_2](https://github.com/user-attachments/assets/017aa8ad-e878-4b4a-87e8-e7e154c9fedb)
![Screenshot_3](https://github.com/user-attachments/assets/9a6286b9-5a78-4564-97d4-ff1ea2ad6f1e)
![Screenshot_4](https://github.com/user-attachments/assets/607c7f4f-3717-4f9c-8b95-5b2e9d989723)
![image](https://github.com/user-attachments/assets/a1369738-9918-4acd-99cf-0d0e688ee72c)
![image](https://github.com/user-attachments/assets/ec85aa75-1c18-46eb-ae5f-780081e55015)

-En el código subido actual, los links en las tablas que contienen texto, son blancos al igual que el resto de la tabla, para que no se pierda el color y no haga difícil la lectura, y para que se entienda que son clickeables tienen un font weight bold, un subrayado, y el ícono de abrir, que es un componente que se utiliza en otros lugares del sitio, además de un tooltip indicando a dónde lleva.
Por otro lado, los links que son números, tienen un badge + tooltip también indicando a dónde llevan.

------Otra variante------
![Screenshot_6](https://github.com/user-attachments/assets/8ebda666-7e7f-4310-ac41-831d7f1ae4ee)
![Screenshot_5](https://github.com/user-attachments/assets/98b642ea-558e-4de0-aa21-1fa978c77e78)

-En esta otra variante (que no está aplicada en el código actual subido), los links con texto, en vez de ser de color blanco, usan text-accent, dándole un color mucho mas llamativo.