### PR TITLE
Solved Password Input Error #100

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -151,7 +151,9 @@ class UserController extends Controller
         $messages = [
             'name.required' => __('users.name').' es requerido',
             'email.required' => __('users.email').' es requerido',
+            'password.required' => __('users.password').' es requerido',
             'password.min' => __('users.password_min').' es requerido',
+            'confirm_password.required' => __('users.confirm_password').' es requerido',
             'confirm_password.same' => __('users.confirm_password').' y '.__('users.password').' no coincide',
         ];
         if (! $isClient) {

--- a/resources/views/admin/users/forms/store-user.blade.php
+++ b/resources/views/admin/users/forms/store-user.blade.php
@@ -26,7 +26,7 @@
                     label="{{ __('users.'.$input) }}"
                     placeholder="{{ __('users.'.$input) }}"
                     error="{{ $errors->has($input) ? $errors->first($input) : null }}"
-                    value="{{ old($input, isset($user) ? $user->{$input} : '') }}"
+                    value="{{ old($input, isset($user) && !in_array($input, ['password', 'confirm_password']) ? $user->{$input} : '') }}"
                     required={{ true }}
             />
         @endif

--- a/resources/views/client/users/forms/store-user.blade.php
+++ b/resources/views/client/users/forms/store-user.blade.php
@@ -14,7 +14,7 @@
                     label="{{ __('users.'.$input) }}"
                     placeholder="{{ __('users.'.$input) }}"
                     error="{{ $errors->has($input) ? $errors->first($input) : null }}"
-                    value="{{ old($input, isset($user) ? $user->{$input} : '') }}"
+                    value="{{ old($input, isset($user) && !in_array($input, ['password', 'confirm_password']) ? $user->{$input} : '') }}"
                     required={{ true }}
             />
         @endif

--- a/resources/views/components/forms/floating-input.blade.php
+++ b/resources/views/components/forms/floating-input.blade.php
@@ -24,7 +24,7 @@
                 @disabled($disabled)
         />
     </label>
-    <p class="validator-hint {{ $error ? 'validator-hint-error bg-error text-error-content p-1.5 rounded' : 'hidden' }}">
+    <p class="validator-hint {{ $error ? 'validator-hint-error bg-error text-error-content p-1.5 rounded visible' : 'hidden' }}">
         {{ $error }}
     </p>
 </div>


### PR DESCRIPTION
## Descripción

Solucionado el problema de que, al querer editar un usuario, el input con el campo de contraseña aparecía completado, con una contraseña incorrecta.
Además se hicieron correcciones para que los mensajes de Feedback de error se muestren correctamente en la vista.

## Issues resueltos

Resolves: #100 

## Checklist

- [ ] He descrito claramente los cambios realizados.
- [ ] He referenciado correctamente las issues que se resuelven.
- [ ] He cumplido todos los puntos referenciados en las issues.