### PR TITLE
Solved Error Deleting User #102

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -207,9 +207,7 @@ class UserController extends Controller
 
             $user->delete();
 
-            $route = $isClient ? 'client.users' : 'admin.users';
-
-            return redirect()->route($route)->with('success', __('users.deleted_successfully'));
+            return redirect()->back()->with('success', __('users.deleted_successfully'));
         } catch (Exception $exception) {
             if (env('APP_ENV') === 'local') {
                 Log::error($exception->getMessage());

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -198,10 +198,18 @@ class UserController extends Controller
     public function UserDelete(int $id): RedirectResponse
     {
         try {
+            $isClient = str_starts_with(request()->route()->getName(), 'client.');
             $user = User::findOrFail($id);
+
+            if ($isClient && (! auth()->check() || $user->client_id !== auth()->user()->client_id)) {
+                abort(403, __('users.edit_permission_error'));
+            }
+
             $user->delete();
 
-            return redirect()->route('admin.users')->with('success', __('users.deleted_successfully'));
+            $route = $isClient ? 'client.users' : 'admin.users';
+
+            return redirect()->route($route)->with('success', __('users.deleted_successfully'));
         } catch (Exception $exception) {
             if (env('APP_ENV') === 'local') {
                 Log::error($exception->getMessage());


### PR DESCRIPTION
## Descripción

Solucionado el error que hacía que al eliminar un usuario logueado como user, se lo redirigía a admin/users, generando que aparezca un mensaje de "Acceso denegado, vista solo para admins".
Ahora ya se concreta la eliminación y es redirigido correctamente.

## Issues resueltos

Resolves: #102 

## Checklist

- [x] He descrito claramente los cambios realizados.
- [x] He referenciado correctamente las issues que se resuelven.
- [x] He cumplido todos los puntos referenciados en las issues.